### PR TITLE
project-viewer: add date filter

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -31,8 +31,10 @@ func CorridorHandler() http.Handler {
 			Issuer: r.FormValue("destIssuer"),
 		}
 
-		startSeq := r.FormValue("start")
-		endSeq := r.FormValue("end")
+		// these start and end timestamps must be integers representing the number of seconds since the Unix epoch
+		startUnixTimestamp := r.FormValue("start")
+		endUnixTimestamp := r.FormValue("end")
+
 		if !source.IsCompleteAsset() || !dest.IsCompleteAsset() {
 			http.Error(w, "Please connect to this URL with parameters sourceCode, sourceIssuer, destCode, destIssuer", 400)
 			return
@@ -43,7 +45,7 @@ func CorridorHandler() http.Handler {
 			http.Error(w, fmt.Sprintf("Error creating BigQuery client: %s", err), 500)
 		}
 
-		results, err := queries.RunCorridorQuery(source, dest, startSeq, endSeq, client)
+		results, err := queries.RunCorridorQuery(source, dest, startUnixTimestamp, endUnixTimestamp, client)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
@@ -75,8 +77,10 @@ func VolumeHandler() http.Handler {
 		volumeFromParam := r.FormValue("volumeFrom")
 		volumeFrom := volumeFromParam != ""
 
-		startSeq := r.FormValue("start")
-		endSeq := r.FormValue("end")
+		// these start and end timestamps must be integers representing the number of seconds since the Unix epoch
+		startUnixTimestamp := r.FormValue("start")
+		endUnixTimestamp := r.FormValue("end")
+
 		if !asset.IsCompleteAsset() {
 			http.Error(w, "Please connect to this URL with parameters code and issuer", 400)
 			return
@@ -87,7 +91,7 @@ func VolumeHandler() http.Handler {
 			http.Error(w, fmt.Sprintf("Error creating BigQuery client: %s", err), 500)
 		}
 
-		results, err := queries.RunVolumeQuery(asset, volumeFrom, startSeq, endSeq, client)
+		results, err := queries.RunVolumeQuery(asset, volumeFrom, startUnixTimestamp, endUnixTimestamp, client)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
@@ -121,8 +125,10 @@ func RateHandler() http.Handler {
 			Issuer: r.FormValue("destIssuer"),
 		}
 
-		startSeq := r.FormValue("start")
-		endSeq := r.FormValue("end")
+		// these start and end timestamps must be integers representing the number of seconds since the Unix epoch
+		startUnixTimestamp := r.FormValue("start")
+		endUnixTimestamp := r.FormValue("end")
+
 		if !source.IsCompleteAsset() || !dest.IsCompleteAsset() {
 			http.Error(w, "Please connect to this URL with parameters sourceCode, sourceIssuer, destCode, destIssuer", 400)
 			return
@@ -133,7 +139,7 @@ func RateHandler() http.Handler {
 			http.Error(w, fmt.Sprintf("Error creating BigQuery client: %s", err), 500)
 		}
 
-		results, err := queries.RunRateQuery(source, dest, startSeq, endSeq, client)
+		results, err := queries.RunRateQuery(source, dest, startUnixTimestamp, endUnixTimestamp, client)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return

--- a/backend/api_corridor_test.go
+++ b/backend/api_corridor_test.go
@@ -36,7 +36,7 @@ func TestCorridorHandler(t *testing.T) {
 		},
 		{
 			name:           "limited range query",
-			r:              httptest.NewRequest("GET", NGNTtoEURTCorridor+"&start=27839022&end=27839022", nil),
+			r:              httptest.NewRequest("GET", NGNTtoEURTCorridor+"&start=1579511535&end=1579511535", nil),
 			w:              httptest.NewRecorder(),
 			expectedStatus: http.StatusOK,
 			golden:         "NGNT_EURT_limited.golden",

--- a/backend/api_rate_test.go
+++ b/backend/api_rate_test.go
@@ -20,7 +20,7 @@ func TestRateHandler(t *testing.T) {
 		},
 		{
 			name:           "limited range query",
-			r:              httptest.NewRequest("GET", rateNGNTtoEURT+"&start=32214562&end=32215487", nil),
+			r:              httptest.NewRequest("GET", rateNGNTtoEURT+"&start=1603315973&end=1603320883", nil),
 			w:              httptest.NewRecorder(),
 			expectedStatus: http.StatusOK,
 			golden:         "NGNT_EURT_limited.golden",
@@ -28,7 +28,7 @@ func TestRateHandler(t *testing.T) {
 		},
 		{
 			name:           "reversed query (values should be reciprocal of above test)",
-			r:              httptest.NewRequest("GET", rateEURTtoNGNT+"&start=32214562&end=32215487", nil),
+			r:              httptest.NewRequest("GET", rateEURTtoNGNT+"&start=1603315973&end=1603320883", nil),
 			w:              httptest.NewRecorder(),
 			expectedStatus: http.StatusOK,
 			golden:         "EURT_NGNT_limited.golden",

--- a/backend/api_volume_test.go
+++ b/backend/api_volume_test.go
@@ -20,7 +20,7 @@ func TestVolumeHandler(t *testing.T) {
 		},
 		{
 			name:           "volumeTo limited range",
-			r:              httptest.NewRequest("GET", volumeToNGNT+"&start=20304878&end=20492609", nil),
+			r:              httptest.NewRequest("GET", volumeToNGNT+"&start=1538627655&end=1539613972", nil),
 			w:              httptest.NewRecorder(),
 			expectedStatus: http.StatusOK,
 			golden:         "NGNT_limited.golden",
@@ -36,7 +36,7 @@ func TestVolumeHandler(t *testing.T) {
 		},
 		{
 			name:           "volumeFrom limited range",
-			r:              httptest.NewRequest("GET", volumeFromCENTUS+"&start=24334355&end=24799948", nil),
+			r:              httptest.NewRequest("GET", volumeFromCENTUS+"&start=1560474979&end=1562964992", nil),
 			w:              httptest.NewRecorder(),
 			expectedStatus: http.StatusOK,
 			golden:         "CENTUS_limited.golden",

--- a/internal/queries/corridor.go
+++ b/internal/queries/corridor.go
@@ -8,8 +8,8 @@ import (
 )
 
 // RunCorridorQuery queries BigQuery for the volume of assets over the specified corridor and returns the results
-func RunCorridorQuery(source, dest Asset, startLedger, endLedger string, client *bigquery.Client) ([]CorridorResult, error) {
-	query := createCorridorQuery(source, dest, startLedger, endLedger)
+func RunCorridorQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string, client *bigquery.Client) ([]CorridorResult, error) {
+	query := createCorridorQuery(source, dest, startUnixTimestamp, endUnixTimestamp)
 	it, err := runQuery(query, client)
 	if err != nil {
 		return nil, fmt.Errorf("error running query \n%s\n%v", query, err)
@@ -32,7 +32,7 @@ func RunCorridorQuery(source, dest Asset, startLedger, endLedger string, client 
 
 // createCorridorQuery returns a query that gets the total source and destination volume through the corridor, grouped by ledger.
 // The volume is calculated by looking at trades between the two assets within the provided ledger range.
-func createCorridorTradeQuery(source, dest Asset, startLedger, endLedger string) string {
+func createCorridorTradeQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string) string {
 	query := "SELECT L.sequence AS seq, SUM(T.base_amount)/10000000 as source, SUM(T.counter_amount)/10000000 as dest"
 	query += " FROM `crypto-stellar.crypto_stellar.history_trades` T"
 	query += " JOIN `crypto-stellar.crypto_stellar.history_assets` B ON B.id=T.base_asset_id"
@@ -44,8 +44,8 @@ func createCorridorTradeQuery(source, dest Asset, startLedger, endLedger string)
 	query += " OR " +
 		fmt.Sprintf("(B.asset_code=\"%s\" AND B.asset_issuer=\"%s\" AND C.asset_code=\"%s\" AND C.asset_issuer=\"%s\"))",
 			dest.Code, dest.Issuer, source.Code, source.Issuer)
-	if startLedger != "" && endLedger != "" {
-		query += fmt.Sprintf(" AND ledger_sequence BETWEEN %s AND %s", startLedger, endLedger)
+	if startUnixTimestamp != "" && endUnixTimestamp != "" {
+		query += fmt.Sprintf(" AND closed_at BETWEEN TIMESTAMP_SECONDS(%s) AND TIMESTAMP_SECONDS(%s)", startUnixTimestamp, endUnixTimestamp)
 	}
 
 	query += fmt.Sprintf(" GROUP BY seq ORDER BY seq ASC LIMIT %d", queryLimit)
@@ -55,13 +55,13 @@ func createCorridorTradeQuery(source, dest Asset, startLedger, endLedger string)
 // createCorridorQuery returns a query that gets the total source and destination volume through the corridor, grouped by ledger.
 // The volume is calculated by looking at successful path payments that start from the source asset and end at the
 // destination asset within the provided ledger range.
-func createCorridorQuery(source, dest Asset, startLedger, endLedger string) string {
+func createCorridorQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string) string {
 	query := "SELECT ledger_sequence as seq, SUM(source_amount) AS source, SUM(amount) AS dest FROM `crypto-stellar.crypto_stellar.enriched_history_operations` WHERE (type=2 OR type=13) AND successful=true"
 	query += " AND " +
 		fmt.Sprintf("(source_asset_code=\"%s\" AND source_asset_issuer=\"%s\" AND asset_code=\"%s\" AND asset_issuer=\"%s\")",
 			source.Code, source.Issuer, dest.Code, dest.Issuer)
-	if startLedger != "" && endLedger != "" {
-		query += fmt.Sprintf(" AND ledger_sequence BETWEEN %s AND %s", startLedger, endLedger)
+	if startUnixTimestamp != "" && endUnixTimestamp != "" {
+		query += fmt.Sprintf(" AND closed_at BETWEEN TIMESTAMP_SECONDS(%s) AND TIMESTAMP_SECONDS(%s)", startUnixTimestamp, endUnixTimestamp)
 	}
 
 	query += fmt.Sprintf(" GROUP BY seq ORDER BY seq ASC LIMIT %d", queryLimit)

--- a/internal/queries/corridor.go
+++ b/internal/queries/corridor.go
@@ -31,7 +31,8 @@ func RunCorridorQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp s
 }
 
 // createCorridorQuery returns a query that gets the total source and destination volume through the corridor, grouped by ledger.
-// The volume is calculated by looking at trades between the two assets within the provided ledger range.
+// The volume is calculated by looking at trades between the two assets within the timestamp range.
+// The timestamps are in UTC to ensure they are consistent with the ledger closed_at timestamps.
 func createCorridorTradeQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string) string {
 	query := "SELECT L.sequence AS seq, SUM(T.base_amount)/10000000 as source, SUM(T.counter_amount)/10000000 as dest"
 	query += " FROM `crypto-stellar.crypto_stellar.history_trades` T"
@@ -54,7 +55,7 @@ func createCorridorTradeQuery(source, dest Asset, startUnixTimestamp, endUnixTim
 
 // createCorridorQuery returns a query that gets the total source and destination volume through the corridor, grouped by ledger.
 // The volume is calculated by looking at successful path payments that start from the source asset and end at the
-// destination asset within the provided ledger range.
+// destination asset within the timestamp range. The timestamps are in UTC to ensure they are consistent with the ledger closed_at timestamps.
 func createCorridorQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string) string {
 	query := "SELECT ledger_sequence as seq, SUM(source_amount) AS source, SUM(amount) AS dest FROM `crypto-stellar.crypto_stellar.enriched_history_operations` WHERE (type=2 OR type=13) AND successful=true"
 	query += " AND " +

--- a/internal/queries/rate.go
+++ b/internal/queries/rate.go
@@ -31,7 +31,8 @@ func RunRateQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp strin
 }
 
 // createRateTradeQuery returns a query that gets the the rate between two assets, grouped by ledger.
-// The volume is calculated by looking at trades involving the assets within the provided ledger range.
+// The volume is calculated by looking at trades involving the assets within the timestamp range.
+// The timestamps are in UTC to ensure they are consistent with the ledger closed_at timestamps.
 func createRateTradeQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string) string {
 	// If the assets map as we expect (source -> base and dest -> counter), then the rate
 	// is the counter amount over the base amount. The rate convert from X source assets to Y dest assets
@@ -65,7 +66,8 @@ func createRateTradeQuery(source, dest Asset, startUnixTimestamp, endUnixTimesta
 
 // createRateQuery returns a query that gets the on-DEX rate between two assets, grouped by ledger.
 // The rate is calculated by looking at historical orderbooks. The average price of the highest bid
-// and the lowest ask are averaged to get the rate at each ledger.
+// and the lowest ask are averaged to get the rate at each ledger. The query calculates rates within the timestamp range.
+// The timestamps are in UTC to ensure they are consistent with the ledger closed_at timestamps.
 func createRateQuery(source, dest Asset, startUnixTimestamp, endUnixTimestamp string) string {
 	normalMatch := fmt.Sprintf("(M.base_code=\"%s\" AND M.base_issuer=\"%s\" AND M.counter_code=\"%s\" AND M.counter_issuer=\"%s\")",
 		source.Code, source.Issuer, dest.Code, dest.Issuer)

--- a/internal/queries/volume.go
+++ b/internal/queries/volume.go
@@ -31,7 +31,8 @@ func RunVolumeQuery(asset Asset, volumeFrom bool, startUnixTimestamp, endUnixTim
 }
 
 // createVolumeTradeQuery returns a query that gets the the total volume to/from an asset, grouped by ledger.
-// The volume is calculated by looking at trades involving the assetswithin the provided ledger range.
+// The volume is calculated by looking at trades involving the assets within the timestamp range.
+// The timestamps are in UTC to ensure they are consistent with the ledger closed_at timestamps.
 func createVolumeTradeQuery(asset Asset, volumeFrom bool, startUnixTimestamp, endUnixTimestamp string) string {
 	//	Construct the base match and select statements. If we want volume from the base asset,
 	//	we need to look at the base_amount. If we want volume to, we look at the counter_amount.
@@ -69,7 +70,8 @@ func createVolumeTradeQuery(asset Asset, volumeFrom bool, startUnixTimestamp, en
 
 // createVolumeQuery returns a query that gets the total volume to/from an asset, grouped by ledger.
 // If volumeFrom is true, then we get the volume from the asset.
-// The volume is calculated by looking at successful path payments involving the asset within the provided ledger range.
+// The volume is calculated by looking at successful path payments involving the asset within the timestamp range.
+// The timestamps are in UTC to ensure they are consistent with the ledger closed_at timestamps.
 func createVolumeQuery(asset Asset, volumeFrom bool, startUnixTimestamp, endUnixTimestamp string) string {
 	equalityPrefix := ""
 	if volumeFrom {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR replaces the previous ledger filter with a date filter. The backend accepts unix start and end timestamps, which are used to filter the query results. Closes #9. Closes #10. Closes #11.

### Why
In the original design, we wanted to filter by date. 

### Known limitations 
